### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I am working at Xibbon building fun mobile applications like [Godot for iPad](ht
 These days, when I am hacking for pleasure, I mostly do it in Swift:
 * [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm) - VT100/Xterm terminal emulator
 * [SwiftGodot](https://github.com/migueldeicaza/SwiftGodot) - Swift bindings for the [Godot game engine](https://godotengine.org)
-* [SwiftGodotKit](https://github.com/migueldeicaza/SwiftGodotKit) - a companion to SwiftGodotKit to drive Godot from Swift.
+* [SwiftGodotKit](https://github.com/migueldeicaza/SwiftGodotKit) - a companion to SwiftGodot to drive Godot from Swift.
 * [SkiaKit](https://github.com/migueldeicaza/SkiaKit) - Swift bindings to the Skia library
 * [TermKit](https://github.com/migueldeicaza/TermKit) - Text mode UI toolkit for Swift
 * [TextBufferKit](https://github.com/migueldeicaza/Textbufferkit) - port of the Visual Studio Code TextBuffer storage engine to Swift


### PR DESCRIPTION
SwiftGodotKit is a companion to SwiftGodot, not a companion to SwiftGodotKit. It's like an infinite recursion.